### PR TITLE
Reinsert default `get_var_nbytes` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,12 @@ impl<B: Backend> Bmi for LstmBmi<B> {
         )
     }
 
+    fn get_var_nbytes(&self, name: &str) -> BmiResult<u32> {
+        let itemsize = self.get_var_itemsize(name)?;
+        let values = self.get_value_ptr(name)?;
+        Ok(values.len() as u32 * itemsize)
+    }
+
     fn get_var_location(&self, name: &str) -> BmiResult<Location> {
         if self.variables.contains_key(name) {
             Ok(Location::Node)


### PR DESCRIPTION
This change reintroduces a default function implementation removed by https://github.com/aaraney/bmi-rs/issues/5. This upstream change has made `rust_lstm` impossible to compile.

Note that the default implementation was removed because a valid value of `get_value_ptr` could not be guaranteed by the interface. This PR assumes that `get_value_ptr` was already correctly implemented for `rust_lstm`, which renders the concern moot.

Once the PR is merged, the module **should function comparably** to binaries compiled prior to the upstream change.

## Additions

Reintroduces former default implementation of `get_var_nbytes`, sourced from https://github.com/aaraney/bmi-rs/issues/5.

## Testing

Confirmed to compile on Linux.
