### PR TITLE
Optimize loading of weights by doing it during the build stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hardcode_weights"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4302,6 +4310,7 @@ dependencies = [
  "burn",
  "burn-import",
  "glob",
+ "hardcode_weights",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ glob = "0.3.3"
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.145"
 serde_yaml = "0.9.34"
+hardcode_weights = { path = "./hardcode_weights" }

--- a/hardcode_weights/Cargo.toml
+++ b/hardcode_weights/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hardcode_weights"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.145"

--- a/hardcode_weights/src/lib.rs
+++ b/hardcode_weights/src/lib.rs
@@ -1,0 +1,57 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use std::fs;
+use serde_json::Value;
+
+fn to_vec(value: &Value) -> Vec<f32> {
+    value
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_f64().unwrap() as f32)
+        .collect()
+}
+
+fn build_weights_function(func_sig: String, weights: Value) -> String {
+    let mut output: String = String::from(func_sig.trim()); // pub fn [function_name] -> Option<Self>
+    output += &format!(" {{\n    return Some(Self {{\n");
+    // This method is technically more opaque than just doing a line-by-line string construction of the function body,
+    // but that method is extremely tedious and hard to read/maintain, so this is a good compromise that
+    // accomplishes the same thing more concisely.
+    for size in ["input_size", "hidden_size", "output_size"] {
+        output += &format!("        {}: {},\n", size, weights[size].as_u64().unwrap() as usize);
+    }
+    for gate in ["input_gate", "forget_gate", "cell_gate", "output_gate"] {
+        output += &format!("        {}_input_weights: vec!{:?},\n", gate, to_vec(&weights[&format!("lstm.{}.input_transform.weight", gate)]));
+        output += &format!("        {}_input_biases: vec!{:?},\n", gate, to_vec(&weights[&format!("lstm.{}.input_transform.bias", gate)]));
+        output += &format!("        {}_hidden_weights: vec!{:?},\n", gate, to_vec(&weights[&format!("lstm.{}.hidden_transform.weight", gate)]));
+        output += &format!("        {}_hidden_biases: vec!{:?},\n", gate, to_vec(&weights[&format!("lstm.{}.hidden_transform.bias", gate)]));
+    }
+    output += "    });\n";
+    output += "}\n";
+    output
+}
+
+#[proc_macro_attribute]
+pub fn hardcode_weights(target: TokenStream, item: TokenStream) -> TokenStream {
+    // Load json weights from file at target path,
+    // overwrite given WeightConfig construction function with one created from scratch.
+    let target_str: String = target.to_string().trim_matches('"').to_string();
+    // grab the part of the string up to the first {, which should be the function signature (e.g. "pub fn nh_AORC_hourly_25yr_1210_112435_7() -> Option<Self>")
+    let func_sig: String = item.to_string().split('{').next().unwrap().to_string();
+
+    let json_str: Result<String, std::io::Error> = fs::read_to_string(&target_str);
+    if let Err(e) = json_str {
+        // Just return the original item if there's an error reading the file
+        eprintln!("Error reading weights file at ({}): {}", target_str, e);
+        return (func_sig.trim().to_string() + " { return None; }\n").parse().unwrap();
+    }
+    let weights: Value = serde_json::from_str(&json_str.unwrap()).unwrap();
+    
+    // eprintln!("Parsed function signature:\n{}", func_sig);
+    // pass the function signature and weights to a helper function that builds the full function string with the weights hardcoded in, then parse that string into a TokenStream and return it
+    let output_function_str: String = build_weights_function(func_sig, weights);
+    // eprintln!("Generated function:\n{}", output_function_str);
+    return output_function_str.parse().unwrap()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 
 mod nextgen_lstm;
 mod python;
+mod weights;
 use nextgen_lstm::{NextgenLstm, vec_to_tensor};
 use python::convert_model;
 
@@ -299,7 +300,8 @@ impl<B: Backend> LstmBmi<B> {
             metadata.output_size,
         );
         model = model.load_record(record);
-        model.load_json_weights(
+        // model.load_json_weights(
+        model.load_weights(
             &self.device,
             burn_dir.join("weights.json").to_str().unwrap(),
         );

--- a/src/nextgen_lstm.rs
+++ b/src/nextgen_lstm.rs
@@ -1,3 +1,4 @@
+use crate::weights::WeightConfig;
 use burn::{
     module::Param,
     nn::{
@@ -60,6 +61,15 @@ pub fn vec_to_tensor(input_vec: &Vec<f32>, shape: Vec<usize>) -> TensorData {
     }
 }
 
+pub fn serde_to_vec(value: &Value) -> Vec<f32> {
+    value
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_f64().unwrap() as f32)
+        .collect()
+}
+
 fn create_gate_controller<B: Backend>(
     input_weights: &Vec<f32>,
     input_biases: &Vec<f32>,
@@ -116,113 +126,100 @@ impl<B: Backend> NextgenLstm<B> {
             .init(device);
         Self { lstm, head }
     }
-    pub fn load_json_weights(&mut self, device: &B::Device, weight_path: &str) {
-        let json_str = fs::read_to_string(weight_path).expect("Failed to read file");
-        let weights: Value = serde_json::from_str(&json_str).unwrap();
-
-        fn to_vec(value: &Value) -> Vec<f32> {
-            value
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|v| v.as_f64().unwrap() as f32)
-                .collect()
+    fn get_json_weights(weight_path: &str) -> Option<WeightConfig> {
+        let json_str = fs::read_to_string(weight_path);
+        if let Err(e) = json_str {
+            eprintln!("Error reading weights file at ({}): {}", weight_path, e);
+            return None;
         }
-
-        let input_size = weights["input_size"].as_u64().unwrap() as usize;
-        let output_size = weights["output_size"].as_u64().unwrap() as usize;
-        let hidden_size = weights["hidden_size"].as_u64().unwrap() as usize;
-
-        // Extract all weights as Vecs
-        let input_gate_input_weights = to_vec(&weights["lstm.input_gate.input_transform.weight"]);
-        let input_gate_input_biases = to_vec(&weights["lstm.input_gate.input_transform.bias"]);
-        let input_gate_hidden_weights = to_vec(&weights["lstm.input_gate.hidden_transform.weight"]);
-        let input_gate_hidden_biases = to_vec(&weights["lstm.input_gate.hidden_transform.bias"]);
+        let weights: Value = serde_json::from_str(&json_str.unwrap()).unwrap();
+        return Some(WeightConfig {
+            input_size: weights["input_size"].as_u64().unwrap() as usize,
+            hidden_size: weights["hidden_size"].as_u64().unwrap() as usize,
+            output_size: weights["output_size"].as_u64().unwrap() as usize,
+            input_gate_input_weights: serde_to_vec(&weights["lstm.input_gate.input_transform.weight"]),
+            input_gate_input_biases: serde_to_vec(&weights["lstm.input_gate.input_transform.bias"]),
+            input_gate_hidden_weights: serde_to_vec(&weights["lstm.input_gate.hidden_transform.weight"]),
+            input_gate_hidden_biases: serde_to_vec(&weights["lstm.input_gate.hidden_transform.bias"]),
+            forget_gate_input_weights: serde_to_vec(&weights["lstm.forget_gate.input_transform.weight"]),
+            forget_gate_input_biases: serde_to_vec(&weights["lstm.forget_gate.input_transform.bias"]),
+            forget_gate_hidden_weights: serde_to_vec(&weights["lstm.forget_gate.hidden_transform.weight"]),
+            forget_gate_hidden_biases: serde_to_vec(&weights["lstm.forget_gate.hidden_transform.bias"]),
+            cell_gate_input_weights: serde_to_vec(&weights["lstm.cell_gate.input_transform.weight"]),
+            cell_gate_input_biases: serde_to_vec(&weights["lstm.cell_gate.input_transform.bias"]),
+            cell_gate_hidden_weights: serde_to_vec(&weights["lstm.cell_gate.hidden_transform.weight"]),
+            cell_gate_hidden_biases: serde_to_vec(&weights["lstm.cell_gate.hidden_transform.bias"]),
+            output_gate_input_weights: serde_to_vec(&weights["lstm.output_gate.input_transform.weight"]),
+            output_gate_input_biases: serde_to_vec(&weights["lstm.output_gate.input_transform.bias"]),
+            output_gate_hidden_weights: serde_to_vec(&weights["lstm.output_gate.hidden_transform.weight"]),
+            output_gate_hidden_biases: serde_to_vec(&weights["lstm.output_gate.hidden_transform.bias"]),
+        });
+    }
+    fn get_hardcoded_weights(weight_path: &str) -> Option<WeightConfig> {
+        let weight_dirname: &str = weight_path.split('/').rev().nth(2).unwrap();
+        match weight_dirname {
+            "nh_AORC_hourly_25yr_1210_112435_7" => WeightConfig::nh_AORC_hourly_25yr_1210_112435_7(),
+            "nh_AORC_hourly_25yr_1210_112435_8" => WeightConfig::nh_AORC_hourly_25yr_1210_112435_8(),
+            "nh_AORC_hourly_25yr_1210_112435_9" => WeightConfig::nh_AORC_hourly_25yr_1210_112435_9(),
+            "nh_AORC_hourly_25yr_seq999_seed101_0701_143442" => WeightConfig::nh_AORC_hourly_25yr_seq999_seed101_0701_143442(),
+            "nh_AORC_hourly_25yr_seq999_seed103_2701_171540" => WeightConfig::nh_AORC_hourly_25yr_seq999_seed103_2701_171540(),
+            "nh_AORC_hourly_slope_elev_precip_temp_seq999_seed101_2801_191806" => WeightConfig::nh_AORC_hourly_slope_elev_precip_temp_seq999_seed101_2801_191806(),
+            _ => None,
+        }
+    }   
+    pub fn load_weightconfig(&mut self, device: &B::Device, weight_config: WeightConfig) {
         self.lstm.input_gate = create_gate_controller(
-            &input_gate_input_weights,
-            &input_gate_input_biases,
-            &input_gate_hidden_weights,
-            &input_gate_hidden_biases,
+            &weight_config.input_gate_input_weights,
+            &weight_config.input_gate_input_biases,
+            &weight_config.input_gate_hidden_weights,
+            &weight_config.input_gate_hidden_biases,
             device,
-            input_size,
-            hidden_size,
+            weight_config.input_size,
+            weight_config.hidden_size,
         );
-
-        let forget_gate_input_weights = to_vec(&weights["lstm.forget_gate.input_transform.weight"]);
-        let forget_gate_input_biases = to_vec(&weights["lstm.forget_gate.input_transform.bias"]);
-        let forget_gate_hidden_weights =
-            to_vec(&weights["lstm.forget_gate.hidden_transform.weight"]);
-        let forget_gate_hidden_biases = to_vec(&weights["lstm.forget_gate.hidden_transform.bias"]);
-
         self.lstm.forget_gate = create_gate_controller(
-            &forget_gate_input_weights,
-            &forget_gate_input_biases,
-            &forget_gate_hidden_weights,
-            &forget_gate_hidden_biases,
+            &weight_config.forget_gate_input_weights,
+            &weight_config.forget_gate_input_biases,
+            &weight_config.forget_gate_hidden_weights,
+            &weight_config.forget_gate_hidden_biases,
             device,
-            input_size,
-            hidden_size,
+            weight_config.input_size,
+            weight_config.hidden_size,
         );
-
-        let cell_gate_input_weights = to_vec(&weights["lstm.cell_gate.input_transform.weight"]);
-        let cell_gate_input_biases = to_vec(&weights["lstm.cell_gate.input_transform.bias"]);
-        let cell_gate_hidden_weights = to_vec(&weights["lstm.cell_gate.hidden_transform.weight"]);
-        let cell_gate_hidden_biases = to_vec(&weights["lstm.cell_gate.hidden_transform.bias"]);
-
         self.lstm.cell_gate = create_gate_controller(
-            &cell_gate_input_weights,
-            &cell_gate_input_biases,
-            &cell_gate_hidden_weights,
-            &cell_gate_hidden_biases,
+            &weight_config.cell_gate_input_weights,
+            &weight_config.cell_gate_input_biases,
+            &weight_config.cell_gate_hidden_weights,
+            &weight_config.cell_gate_hidden_biases,
             device,
-            input_size,
-            hidden_size,
+            weight_config.input_size,
+            weight_config.hidden_size,
         );
-
-        let output_gate_input_weights = to_vec(&weights["lstm.output_gate.input_transform.weight"]);
-        let output_gate_input_biases = to_vec(&weights["lstm.output_gate.input_transform.bias"]);
-        let output_gate_hidden_weights =
-            to_vec(&weights["lstm.output_gate.hidden_transform.weight"]);
-        let output_gate_hidden_biases = to_vec(&weights["lstm.output_gate.hidden_transform.bias"]);
-
         self.lstm.output_gate = create_gate_controller(
-            &output_gate_input_weights,
-            &output_gate_input_biases,
-            &output_gate_hidden_weights,
-            &output_gate_hidden_biases,
+            &weight_config.output_gate_input_weights,
+            &weight_config.output_gate_input_biases,
+            &weight_config.output_gate_hidden_weights,
+            &weight_config.output_gate_hidden_biases,
             device,
-            input_size,
-            hidden_size,
+            weight_config.input_size,
+            weight_config.hidden_size,
         );
-
-        // let head_weights = to_vec(&weights["head.weight"]);
-        // let head_biases = to_vec(&weights["head.bias"]);
-
-        // // Print to verify
-        // println!("Input gate input weights: {:?}", input_gate_input_weights);
-        // println!("Input gate input biases: {:?}", input_gate_input_biases);
-        // println!("Input gate hidden weights: {:?}", input_gate_hidden_weights);
-        // println!("Input gate hidden biases: {:?}", input_gate_hidden_biases);
-        // println!("Forget gate input weights: {:?}", forget_gate_input_weights);
-        // println!("Forget gate input biases: {:?}", forget_gate_input_biases);
-        // println!(
-        //     "Forget gate hidden weights: {:?}",
-        //     forget_gate_hidden_weights
-        // );
-        // println!("Forget gate hidden biases: {:?}", forget_gate_hidden_biases);
-        // println!("Cell gate input weights: {:?}", cell_gate_input_weights);
-        // println!("Cell gate input biases: {:?}", cell_gate_input_biases);
-        // println!("Cell gate hidden weights: {:?}", cell_gate_hidden_weights);
-        // println!("Cell gate hidden biases: {:?}", cell_gate_hidden_biases);
-        // println!("Output gate input weights: {:?}", output_gate_input_weights);
-        // println!("Output gate input biases: {:?}", output_gate_input_biases);
-        // println!(
-        //     "Output gate hidden weights: {:?}",
-        //     output_gate_hidden_weights
-        // );
-        // println!("Output gate hidden biases: {:?}", output_gate_hidden_biases);
-
-        // // Repeat for other gates...
+    }
+    pub fn load_json_weights(&mut self, device: &B::Device, weight_path: &str) {
+        let weight_config = Self::get_json_weights(weight_path);
+        if weight_config.is_none() {
+            panic!("Failed to load weights from path: {}", weight_path);
+        } else {
+            self.load_weightconfig(device, weight_config.unwrap());
+        }
+    }
+    pub fn load_weights(&mut self, device: &B::Device, weight_path: &str) {
+        // Try to load hardcoded weights first, then fall back to json loading if that fails
+        if let Some(weight_config) = Self::get_hardcoded_weights(weight_path) {
+            self.load_weightconfig(device, weight_config);
+        } else {
+            self.load_json_weights(device, weight_path);
+        }
     }
 
     pub fn forward(

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -1,0 +1,39 @@
+use hardcode_weights::hardcode_weights;
+
+#[allow(dead_code)] // suppress warning about the unused output_size field, since it might get used later
+pub struct WeightConfig {
+    pub input_size: usize,
+    pub hidden_size: usize,
+    pub output_size: usize,
+    pub input_gate_input_weights: Vec<f32>,
+    pub input_gate_input_biases: Vec<f32>,
+    pub input_gate_hidden_weights: Vec<f32>,
+    pub input_gate_hidden_biases: Vec<f32>,
+    pub forget_gate_input_weights: Vec<f32>,
+    pub forget_gate_input_biases: Vec<f32>,
+    pub forget_gate_hidden_weights: Vec<f32>,
+    pub forget_gate_hidden_biases: Vec<f32>,
+    pub cell_gate_input_weights: Vec<f32>,
+    pub cell_gate_input_biases: Vec<f32>,
+    pub cell_gate_hidden_weights: Vec<f32>,
+    pub cell_gate_hidden_biases: Vec<f32>,
+    pub output_gate_input_weights: Vec<f32>,
+    pub output_gate_input_biases: Vec<f32>,
+    pub output_gate_hidden_weights: Vec<f32>,
+    pub output_gate_hidden_biases: Vec<f32>,
+}
+
+impl WeightConfig {
+    #[hardcode_weights("/ngen/ngen/extern/lstm/trained_neuralhydrology_models/nh_AORC_hourly_25yr_1210_112435_7/burn/weights.json")]
+    pub fn nh_AORC_hourly_25yr_1210_112435_7() -> Option<Self> {}
+    #[hardcode_weights("/ngen/ngen/extern/lstm/trained_neuralhydrology_models/nh_AORC_hourly_25yr_1210_112435_8/burn/weights.json")]
+    pub fn nh_AORC_hourly_25yr_1210_112435_8() -> Option<Self> {}
+    #[hardcode_weights("/ngen/ngen/extern/lstm/trained_neuralhydrology_models/nh_AORC_hourly_25yr_1210_112435_9/burn/weights.json")]
+    pub fn nh_AORC_hourly_25yr_1210_112435_9() -> Option<Self> {}
+    #[hardcode_weights("/ngen/ngen/extern/lstm/trained_neuralhydrology_models/nh_AORC_hourly_25yr_seq999_seed101_0701_143442/burn/weights.json")]
+    pub fn nh_AORC_hourly_25yr_seq999_seed101_0701_143442() -> Option<Self> {}
+    #[hardcode_weights("/ngen/ngen/extern/lstm/trained_neuralhydrology_models/nh_AORC_hourly_25yr_seq999_seed103_2701_171540/burn/weights.json")]
+    pub fn nh_AORC_hourly_25yr_seq999_seed103_2701_171540() -> Option<Self> {}
+    #[hardcode_weights("/ngen/ngen/extern/lstm/trained_neuralhydrology_models/nh_AORC_hourly_slope_elev_precip_temp_seq999_seed101_2801_191806/burn/weights.json")]
+    pub fn nh_AORC_hourly_slope_elev_precip_temp_seq999_seed101_2801_191806() -> Option<Self> {}
+}


### PR DESCRIPTION
Loading weights from JSON was taking what seemed to be a majority of the runtime (at least when running through the route_rs dev branch), by loading the 6 sets of LSTM weights at least once for every individual catchment. 
By moving this load method to the build stage with a dynamic macro, we limit it to one load for each set of weights total.
<img width="1423" height="519" alt="image" src="https://github.com/user-attachments/assets/50c5fa56-c150-41eb-95bd-9b62b914acc2" />
This is likely not the most optimal method of loading weights, but by making the process (mostly) a single operation, the overall effect on runtime should be minimal, especially if there are multiple runs per build.

However, the biggest pitfall of this method is that it assumes the weights will be in the same place every time, the place it expects them to be within a NGIAB container. If this model is to be run in any other way, the paths will need to be modified somehow. This is not the biggest issue, as a change to weight location would already require modifying each of the relevant .yml files for each catchment, but it is a concern to note.

## Additions

- Proc-macro submodule for loading the weights during the build process.
- `weights.rs` file to run the macros and contain a relevant data structure.

## Changes

- Modified the weight loading functionality to try the hardcoded method first, and rely on a variant of the old json method as a fallback.
